### PR TITLE
Ensure SiteConfig class exists before calling it.

### DIFF
--- a/code/extensions/ModernoAdminExtension.php
+++ b/code/extensions/ModernoAdminExtension.php
@@ -10,7 +10,7 @@ class ModernoAdminExtension extends LeftAndMainExtension
      */
     public function init()
     {
-        if ($SiteConfig = SiteConfig::current_site_config()) {
+        if (class_exists("SiteConfig") && $SiteConfig = SiteConfig::current_site_config()) {
             Requirements::customCSS($SiteConfig->renderWith('ModernoAdminCustomCSS'));
         }
     }


### PR DESCRIPTION
This current release breaks the admin area on framework only installations as framework does not contain the SiteConfig class. Check that it exists before calling it.
